### PR TITLE
Add TypeScript compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maseya/z3pr",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "scripts": {
     "test": "mocha -r esm \"./spec/**/*_spec.js\"",
     "build": "browserify -d -s z3pr -t babelify -p tinyify src/index.js | exorcist dist/z3pr-umd.map.js > dist/z3pr-umd.js"
@@ -19,6 +19,7 @@
     "tinyify": "^3.0.0"
   },
   "main": "src/index.js",
+  "types": "src/index.d.ts",
   "files": [
     "src/**",
     "*.md"

--- a/spec/color_f_spec.js
+++ b/spec/color_f_spec.js
@@ -1,10 +1,10 @@
-import with_cases from './with_cases';
+import with_cases from './with_cases.js';
 import chai from 'chai';
 chai.should();
 
-import map from 'lodash/map';
+import map from 'lodash/map.js';
 
-import color_f from '../src/color_f';
+import color_f from '../src/color_f.js';
 
 const delta = 10e-9;
 

--- a/spec/maseya_blend_spec.js
+++ b/spec/maseya_blend_spec.js
@@ -1,14 +1,14 @@
 import chai from 'chai';
 chai.should();
 
-import times from 'lodash/times';
-import random from 'lodash/random';
+import times from 'lodash/times.js';
+import random from 'lodash/random.js';
 
 const { abs, min } = Math;
 
-import color_f from '../src/color_f';
+import color_f from '../src/color_f.js';
 
-import { maseya_blend } from '../src/blends';
+import { maseya_blend } from '../src/blends.js';
 
 const delta = 10e-9;
 const repeats = 500;

--- a/spec/system_spec.js
+++ b/spec/system_spec.js
@@ -1,26 +1,26 @@
-import with_cases from './with_cases';
+import with_cases from './with_cases.js';
 import chai from 'chai';
 chai.should();
 
-import map from 'lodash/map';
-import slice from 'lodash/slice';
-import concat from 'lodash/concat';
-import keys from 'lodash/keys';
-import toPairs from 'lodash/toPairs';
-import parseInt from 'lodash/parseInt';
+import map from 'lodash/map.js';
+import slice from 'lodash/slice.js';
+import concat from 'lodash/concat.js';
+import keys from 'lodash/keys.js';
+import toPairs from 'lodash/toPairs.js';
+import parseInt from 'lodash/parseInt.js';
 
-import base from './data/base.json';
-import negative from './data/negative.json';
-import grayscale from './data/grayscale.json';
-import maseya from './data/maseya.json';
-import classic from './data/classic.json';
-import dizzy from './data/dizzy.json';
-import sick from './data/sick.json';
-import puke from './data/puke.json';
+import base from './data/base.json' with { type: 'json' };
+import negative from './data/negative.json' with { type: 'json' };
+import grayscale from './data/grayscale.json' with { type: 'json' };
+import maseya from './data/maseya.json' with { type: 'json' };
+import classic from './data/classic.json' with { type: 'json' };
+import dizzy from './data/dizzy.json' with { type: 'json' };
+import sick from './data/sick.json' with { type: 'json' };
+import puke from './data/puke.json' with { type: 'json' };
 
-import color_f from '../src/color_f';
+import color_f from '../src/color_f.js';
 
-import { randomize } from '../src/';
+import { randomize } from '../src/index.js';
 
 describe('Palette randomizer', () => {
 

--- a/spec/with_cases.js
+++ b/spec/with_cases.js
@@ -1,7 +1,7 @@
-import each from 'lodash/each';
-import toPairs from 'lodash/toPairs';
-import castArray from 'lodash/castArray';
-import isPlainObject from 'lodash/isPlainObject';
+import each from 'lodash/each.js';
+import toPairs from 'lodash/toPairs.js';
+import castArray from 'lodash/castArray.js';
+import isPlainObject from 'lodash/isPlainObject.js';
 
 // Invokes the predicate with the arguments supplied through 'cases'.
 //

--- a/src/blends.js
+++ b/src/blends.js
@@ -1,7 +1,7 @@
-import color_f from './color_f';
+import color_f from './color_f.js';
 
-import map from 'lodash/map';
-import at from 'lodash/at';
+import map from 'lodash/map.js';
+import at from 'lodash/at.js';
 
 const { max, sqrt } = Math;
 

--- a/src/color_f.js
+++ b/src/color_f.js
@@ -1,8 +1,8 @@
-import { max, min } from './util';
+import { max, min } from './util.js';
 
-import at from 'lodash/at';
-import isEqual from 'lodash/isEqual';
-import clamp from 'lodash/clamp';
+import at from 'lodash/at.js';
+import isEqual from 'lodash/isEqual.js';
+import clamp from 'lodash/clamp.js';
 
 const { abs } = Math;
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,49 @@
+export declare function color_f(r: number, g: number, b: number): PaletteModifier;
+
+/**
+ * Applies a randomized palette to a deep copy of the given ROM data.
+ * @param rom The ROM data to modify.
+ * @param args A rest parameter of additional arguments to provide.
+ * @returns The modified deep copy of the original ROM data.
+ */
+export function randomize_copy<T extends SeedValue>(rom: Uint8Array, ...args: Array<PaletteRandomizerOptions<T> | ((seed: T) => Generator<PaletteModifier>)>): Uint8Array;
+
+/**
+ * Applies a randomized palette to the given ROM data.
+ * @param rom The ROM data to modify.
+ * @param options An object containing information regarding the randomization
+ * mode to use and what aspects of the ROM should be affected.
+ * @param next_blend An optional generator function that returns a sequence of
+ * color blend values.
+ * @returns The modified ROM data.
+ */
+export function randomize<T extends SeedValue>(rom: Uint8Array, options?: PaletteRandomizerOptions<T>, next_blend?: (seed: T) => Generator<PaletteModifier>): Uint8Array;
+
+type PaletteRandomizerOptions<T extends SeedValue> = {
+    mode?: PaletteMode,
+    randomize_overworld?: boolean,
+    randomize_dungeon?: boolean,
+    randomize_link_sprite?: boolean,
+    randomize_sword?: boolean,
+    randomize_shield?: boolean,
+    randomize_hud?: boolean,
+    seed?: T,
+};
+
+type PaletteModifier = {
+    r: number,
+    g: number,
+    b: number,
+    hue: () => number,
+    chroma: () => number,
+    saturation: () => number,
+    luma: () => number,
+    lightness: () => number,
+    grayscale: () => PaletteModifier,
+    invert: () => PaletteModifier,
+};
+
+type SeedValue = number | [number, number] | [number, number, number];
+
+type PaletteMode = 'none' | 'maseya' | 'grayscale' | 'negative' | 'blackout' |
+    'classic' | 'dizzy' | 'sick' | 'puke';

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -6,7 +6,7 @@ export declare function color_f(r: number, g: number, b: number): PaletteModifie
  * @param args A rest parameter of additional arguments to provide.
  * @returns The modified deep copy of the original ROM data.
  */
-export function randomize_copy<T extends SeedValue>(rom: Uint8Array, ...args: Array<PaletteRandomizerOptions<T> | ((seed: T) => Generator<PaletteModifier>)>): Uint8Array;
+export function randomize_copy<T extends SeedValue>(rom: Uint8Array, ...args: Array<PaletteRandomizerOptions<T> | ((seed: T) => Generator<PaletteModifier, void, unknown>)>): Uint8Array;
 
 /**
  * Applies a randomized palette to the given ROM data.
@@ -17,7 +17,7 @@ export function randomize_copy<T extends SeedValue>(rom: Uint8Array, ...args: Ar
  * color blend values.
  * @returns The modified ROM data.
  */
-export function randomize<T extends SeedValue>(rom: Uint8Array, options?: PaletteRandomizerOptions<T>, next_blend?: (seed: T) => Generator<PaletteModifier>): Uint8Array;
+export function randomize<T extends SeedValue>(rom: Uint8Array, options?: PaletteRandomizerOptions<T>, next_blend?: (seed: T) => Generator<PaletteModifier, void, unknown>): Uint8Array;
 
 type PaletteRandomizerOptions<T extends SeedValue> = {
     mode?: PaletteMode,

--- a/src/index.js
+++ b/src/index.js
@@ -1,15 +1,15 @@
-import build_offsets from './offsets/';
-import palette_editor from './palette_editor';
-import { maseya_blend, classic_blend } from './blends';
+import build_offsets from './offsets/index.js';
+import palette_editor from './palette_editor.js';
+import { maseya_blend, classic_blend } from './blends.js';
 
-import color_f from './color_f';
-import random from './random';
+import color_f from './color_f.js';
+import random from './random/index.js';
 
-import map from 'lodash/map';
-import each from 'lodash/each';
-import castArray from 'lodash/castArray';
+import map from 'lodash/map.js';
+import each from 'lodash/each.js';
+import castArray from 'lodash/castArray.js';
 
-export { default as color_f } from './color_f';
+export { default as color_f } from './color_f.js';
 
 export function randomize_copy(rom, ...args) { return randomize(rom.slice(), ...args); }
 

--- a/src/offsets/index.js
+++ b/src/offsets/index.js
@@ -1,12 +1,12 @@
-import dungeon from './dungeon';
-import hud from './hud';
-import link_sprite from './link_sprite';
-import shield from './shield';
-import sword from './sword';
-import overworld from './overworld';
+import dungeon from './dungeon.json' with { type: 'json' };
+import hud from './hud.json' with { type: 'json' };
+import link_sprite from './link_sprite.json' with { type: 'json' };
+import shield from './shield.json' with { type: 'json' };
+import sword from './sword.json' with { type: 'json' };
+import overworld from './overworld.json' with { type: 'json' };
 
-import compact from 'lodash/compact';
-import flatten from 'lodash/flatten';
+import compact from 'lodash/compact.js';
+import flatten from 'lodash/flatten.js';
 
 export default function(options) {
     return flatten(

--- a/src/palette_editor.js
+++ b/src/palette_editor.js
@@ -1,13 +1,13 @@
-import color_f from './color_f';
+import color_f from './color_f.js';
 
-import { group_values_ordered } from './util';
-import { le_dw_value, le_dw_bytes } from './util';
+import { group_values_ordered } from './util.js';
+import { le_dw_value, le_dw_bytes } from './util.js';
 
-import each from 'lodash/each';
-import mapValues from 'lodash/mapValues';
-import transform from 'lodash/transform';
-import clamp from 'lodash/clamp';
-import parseInt from 'lodash/parseInt';
+import each from 'lodash/each.js';
+import mapValues from 'lodash/mapValues.js';
+import transform from 'lodash/transform.js';
+import clamp from 'lodash/clamp.js';
+import parseInt from 'lodash/parseInt.js';
 
 export default function (rom, offsets) {
     const methods = {};

--- a/src/random/index.js
+++ b/src/random/index.js
@@ -1,7 +1,7 @@
-import sfc32 from './sfc32';
+import sfc32 from './sfc32.js';
 
-import times from 'lodash/times';
-import isEmpty from 'lodash/isEmpty';
+import times from 'lodash/times.js';
+import isEmpty from 'lodash/isEmpty.js';
 
 const inclusive_max = 0xFFFFFFFF;
 const exclusive_max = 0x100000000;

--- a/src/random/sfc32.js
+++ b/src/random/sfc32.js
@@ -1,4 +1,4 @@
-import isNil from 'lodash/isNil';
+import isNil from 'lodash/isNil.js';
 
 export default function sfc32(s1, s2, s3) {
     let a, b, c, n;

--- a/src/util.js
+++ b/src/util.js
@@ -1,8 +1,8 @@
-import map from 'lodash/map';
-import groupBy from 'lodash/groupBy';
-import findIndex from 'lodash/findIndex';
-import _max from 'lodash/max';
-import _min from 'lodash/min';
+import map from 'lodash/map.js';
+import groupBy from 'lodash/groupBy.js';
+import findIndex from 'lodash/findIndex.js';
+import _max from 'lodash/max.js';
+import _min from 'lodash/min.js';
 
 // Creates an array composed of value-group pairs, where each value is a
 // representative element from`collection` and its group is an array of


### PR DESCRIPTION
# Purpose
The intent behind this pull request is to enable z3pr to have proper TypeScript project compatibility and documentation. While there is sufficient documentation in the [README](../README.md), it is not present in the actual source code. This is inconvenient for two reasons:
1. You can't take advantage of autocomplete/IntelliSense to resolve the optional parameters in the randomize function.
2. The module cannot be used in TypeScript-based projects without changing tsconfig options to accommodate for JS-only modules and implicit-any return types.

# Changes
For this module to be TypeScript-compatible, I introduce the following changes:
* Add index.d.ts file to properly type and document exposed functions
* Replace all ambiguous file imports with explicit file paths (including lodash imports)
* Add import attributes for all JSON module imports

The actual code itself is otherwise unchanged from commit [a416a81](https://github.com/Maseya/z3pr-js/commit/a416a81d2d974e6221a5f3ed5f874bed3ceaf264) and functions exactly the same.

## Breaking Changes
Adding import attributes for JSON modules introduces a breaking change for Node.js projects on versions older than v20.18.3. This can be fixed by converting all .json files to .js files, negating the need for import attributes.

# Tests
Although I do not have a benchmark test supplied in a commit to this repository, I have been making use of this module in a private repository that is TypeScript-based.
![Code_EwVMhMA67X](https://github.com/user-attachments/assets/ee9b0454-e0e0-478f-9649-f5addacd5dba)
(The function in question:)
![Code_6TRNqBVIb2](https://github.com/user-attachments/assets/8d7f09d7-d0c6-4d4a-9805-6866c8b71a99)


# Other Screenshots
![Code_nXsqJ7rzkM](https://github.com/user-attachments/assets/84d45e00-0c82-4e17-9069-8ede28d9a5e9)
![Code_nrpv9TiJAP](https://github.com/user-attachments/assets/ba1c1762-c10b-4596-bc5a-e528da0e3f59)
![Code_PSfjzi7Tm3](https://github.com/user-attachments/assets/922ffb2c-8f69-459b-83fe-f1716c58da4e)